### PR TITLE
Framework update.

### DIFF
--- a/src/main/java/com/github/cao/awa/trtr/annotation/mine/repo/MineableAnnotations.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/mine/repo/MineableAnnotations.java
@@ -87,61 +87,38 @@ public class MineableAnnotations {
 
     public static void putDefaults() {
         register(AxeMining.class,
-
-                 Identifier.of("minecraft",
-                               "mineable/axe"
-                 )
+                 Identifier.tryParse("minecraft:mineable/axe")
         );
         register(HoeMining.class,
-                 Identifier.of("minecraft",
-                               "mineable/hoe"
-                 )
+                 Identifier.tryParse("minecraft:mineable/hoe")
         );
         register(PickaxeMining.class,
-                 Identifier.of("minecraft",
-                               "mineable/pickaxe"
-                 )
+                 Identifier.tryParse("minecraft:mineable/pickaxe")
         );
         register(ShearsMining.class,
-                 Identifier.of("minecraft",
-                               "mineable/shear"
-                 )
+                 Identifier.tryParse("minecraft:mineable/shear")
         );
         register(ShovelMining.class,
-                 Identifier.of("minecraft",
-                               "mineable/shovel"
-                 )
+                 Identifier.tryParse("minecraft:mineable/shovel")
         );
         register(SwordMining.class,
-                 Identifier.of("minecraft",
-                               "mineable/sword"
-                 )
+                 Identifier.tryParse("minecraft:mineable/sword")
         );
 
         register(MiningLevels.WOOD,
-                 Identifier.of("minecraft",
-                               "needs_wood_tool"
-                 )
+                 Identifier.tryParse("minecraft:needs_wood_tool")
         );
         register(MiningLevels.STONE,
-                 Identifier.of("minecraft",
-                               "needs_stone_tool"
-                 )
+                 Identifier.tryParse("minecraft:needs_stone_tool")
         );
         register(MiningLevels.IRON,
-                 Identifier.of("minecraft",
-                               "needs_iron_tool"
-                 )
+                 Identifier.tryParse("minecraft:needs_iron_tool")
         );
         register(MiningLevels.DIAMOND,
-                 Identifier.of("minecraft",
-                               "needs_diamond_tool"
-                 )
+                 Identifier.tryParse("minecraft:needs_diamond_tool")
         );
         register(MiningLevels.NETHERITE,
-                 Identifier.of("minecraft",
-                               "needs_netherite_tool"
-                 )
+                 Identifier.tryParse("minecraft:needs_netherite_tool")
         );
     }
 }

--- a/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
@@ -25,9 +25,7 @@ import net.minecraft.util.Identifier;
 public class ExampleBlock extends TrtrBlock {
     // Identifier.
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "example"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:example");
 
     // Settings.
     @Auto

--- a/src/main/java/com/github/cao/awa/trtr/block/example/simple/SimpleExampleBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/simple/SimpleExampleBlock.java
@@ -24,9 +24,7 @@ import net.minecraft.util.Identifier;
 public class SimpleExampleBlock extends TrtrBlockWithEntity {
     // Identifier.
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "example_simple"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:example_simple");
 
     // Settings.
     @Auto

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/alunite/Alunite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/alunite/Alunite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Alunite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "alunite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:alunite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/bauxite/Bauxite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/bauxite/Bauxite.java
@@ -16,9 +16,8 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Bauxite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "bauxite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:bauxite");
+
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/bauxite/DeepslateBauxite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/aluminum/bauxite/DeepslateBauxite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateBauxite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_bauxite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_bauxite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/copper/chalcopyrite/Chalcopyrite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/copper/chalcopyrite/Chalcopyrite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Chalcopyrite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "chalcopyrite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:chalcopyrite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/copper/chalcopyrite/DeepslateChalcopyrite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/copper/chalcopyrite/DeepslateChalcopyrite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateChalcopyrite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_chalcopyrite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_chalcopyrite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/copper/cuprite/Cuprite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/copper/cuprite/Cuprite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Cuprite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "cuprite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:cuprite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/copper/cuprite/DeepslateCuprite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/copper/cuprite/DeepslateCuprite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateCuprite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_cuprite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_cuprite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/copper/malachite/Malachite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/copper/malachite/Malachite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Malachite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "malachite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:malachite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/albite/Albite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/albite/Albite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Albite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "albite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:albite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/anorthite/Anorthite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/anorthite/Anorthite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Anorthite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "anorthite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:anorthite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/orthoclase/Orthoclase.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/feldspar/orthoclase/Orthoclase.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Orthoclase extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "orthoclase"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:orthoclase");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/iron/magnetite/DeepslateMagnetite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/iron/magnetite/DeepslateMagnetite.java
@@ -16,9 +16,8 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateMagnetite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_magnetite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_magnetite");
+
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,
                                                                               DyeColor.BLACK

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/iron/magnetite/Magnetite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/iron/magnetite/Magnetite.java
@@ -16,9 +16,8 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Magnetite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "magnetite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:magnetite");
+
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,
                                                                               DyeColor.BLACK

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/lead/galena/DeepslateGalena.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/lead/galena/DeepslateGalena.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateGalena extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_galena"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_galena");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/lead/galena/Galena.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/lead/galena/Galena.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Galena extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "galena"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:galena");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/limestone/Limestone.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/limestone/Limestone.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Limestone extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "limestone"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:limestone");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/marble/Marble.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/marble/Marble.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Marble extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "marble"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:marble");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/autunite/Autunite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/autunite/Autunite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Autunite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "autunite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:autunite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/autunite/DeepslateAutunite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/autunite/DeepslateAutunite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateAutunite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_autunite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_autunite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/carnotite/Carnotite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/carnotite/Carnotite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Carnotite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "carnotite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:carnotite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/carnotite/DeepslateCarnotite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/carnotite/DeepslateCarnotite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateCarnotite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_carnotite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_carnotite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/pitchblende/DeepslatePitchblende.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/pitchblende/DeepslatePitchblende.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslatePitchblende extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_pitchblende"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_pitchblende");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/pitchblende/Pitchblende.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/nuclear/uranium/pitchblende/Pitchblende.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Pitchblende extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "pitchblende"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:pitchblende");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/salt/halite/Halite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/salt/halite/Halite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Halite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "halite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:halite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/sliver/acanthite/Acanthite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/sliver/acanthite/Acanthite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Acanthite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "acanthite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:acanthite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/sliver/acanthite/DeepslateAcanthite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/sliver/acanthite/DeepslateAcanthite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateAcanthite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_acanthite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_acanthite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/ilmenite/DeepslateIlmenite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/ilmenite/DeepslateIlmenite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class DeepslateIlmenite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "deepslate_ilmenite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:deepslate_ilmenite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/ilmenite/Ilmenite.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/ilmenite/Ilmenite.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Ilmenite extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "ilmenite"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:ilmenite");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/rutile/Rutile.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/ore/titanium/rutile/Rutile.java
@@ -16,9 +16,7 @@ import net.minecraft.util.Identifier;
 @PickaxeMining(MiningLevels.STONE)
 public class Rutile extends TrtrBlock {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "rutile"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:rutile");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.STONE,

--- a/src/main/java/com/github/cao/awa/trtr/block/stove/mud/MudStove.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/stove/mud/MudStove.java
@@ -35,9 +35,7 @@ import net.minecraft.world.World;
 @Unsupported
 public class MudStove extends TrtrBlockWithEntity {
     @Auto
-    public static final Identifier IDENTIFIER = Identifier.of("trtr",
-                                                              "mud_stove"
-    );
+    public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:mud_stove");
 
     @Auto
     public static final FabricBlockSettings SETTINGS = FabricBlockSettings.of(Material.SOIL,

--- a/src/main/java/com/github/cao/awa/trtr/framework/accessor/identifier/IdentifierAccessor.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/accessor/identifier/IdentifierAccessor.java
@@ -2,14 +2,42 @@ package com.github.cao.awa.trtr.framework.accessor.identifier;
 
 import com.github.cao.awa.trtr.framework.accessor.filed.FieldAccessor;
 import net.minecraft.util.Identifier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class IdentifierAccessor implements FieldAccessor {
+    private static final Logger LOGGER = LogManager.getLogger("IdentifierAccessor");
     public static final IdentifierAccessor ACCESSOR = new IdentifierAccessor();
 
     public Identifier get(Class<?> clazz) {
-        return get(clazz,
-                   "IDENTIFIER"
+        Object fieldResult = get(clazz,
+                                 "IDENTIFIER"
         );
+        if (fieldResult instanceof Identifier identifier) {
+            return identifier;
+        }
+        LOGGER.warn("Access 'IDENTIFIER' in {} as identifier failed, trying parse with string",
+                    clazz.getName()
+        );
+
+        Identifier identifier;
+        try {
+            String[] paths = fieldResult.toString()
+                                        .split(":");
+
+            identifier = Identifier.of(paths[0],
+                                       paths[1]
+            );
+        } catch (Exception e) {
+            identifier = null;
+        }
+
+        if (identifier == null) {
+            LOGGER.error("Access 'IDENTIFIER' in '{}' failed parse to identifier with string",
+                         clazz.getName()
+            );
+        }
+        return identifier;
     }
 
     public Identifier get(Object o) {

--- a/src/main/java/com/github/cao/awa/trtr/framework/block/BlockFramework.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/block/BlockFramework.java
@@ -299,6 +299,13 @@ public class BlockFramework extends ReflectionFramework {
         EntrustEnvironment.trys(() -> {
                                     Identifier identifier = IdentifierAccessor.ACCESSOR.get(block);
 
+                                    // Do not build null identifier block.
+                                    // Null identifier means something was wrong.
+                                    if (identifier == null) {
+                                        LOGGER.error("Got null identifier, cancel building block '{}'", block.getClass().getName());
+                                        return;
+                                    }
+
                                     // Register this block to vanilla.
                                     Registry.register(Registries.BLOCK,
                                                       identifier,

--- a/src/main/java/com/github/cao/awa/trtr/framework/block/data/gen/tag/BlockTagDataGenFramework.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/block/data/gen/tag/BlockTagDataGenFramework.java
@@ -88,7 +88,7 @@ public class BlockTagDataGenFramework extends ReflectionFramework {
                          .getName()
         );
 
-        TrtrTagFactory factory = create(block);
+        TrtrTagFactory factory = factory(block);
 
         if (factory == null) {
             LOGGER.error("Failed construct the data provider for '{}', if this block using LootFactory<T>, then maybe type has been erasure by java",
@@ -116,7 +116,7 @@ public class BlockTagDataGenFramework extends ReflectionFramework {
         return true;
     }
 
-    private TrtrTagFactory create(Block block) {
+    private TrtrTagFactory factory(Block block) {
         try {
             final TrtrTagFactory factory = (output, registryKey, future) -> TagDataGeneratorAccessor.ACCESSOR.get(block);
             if (EntrustEnvironment.trys(() -> factory.apply(null,


### PR DESCRIPTION
The 'IDENTIFIER' can use string now, like: String IDENTIFIER = "trtr:example";. 
Replaced all 'Identifier.of' to 'Identifier.tryParse' in blocks.