### PR TITLE
Frmework update

### DIFF
--- a/src/main/java/com/github/cao/awa/trtr/TrtrMod.java
+++ b/src/main/java/com/github/cao/awa/trtr/TrtrMod.java
@@ -6,14 +6,7 @@ import com.github.cao.awa.trtr.annotation.mine.repo.MineableAnnotations;
 import com.github.cao.awa.trtr.command.GetAllTrtrBlockCommand;
 import com.github.cao.awa.trtr.framework.block.BlockFramework;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
-import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
-import net.minecraft.registry.RegistryKey;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.util.Identifier;
-import net.minecraft.world.gen.GenerationStep;
-import net.minecraft.world.gen.feature.PlacedFeature;
 
 @Client
 @Server
@@ -32,18 +25,6 @@ public class TrtrMod implements ModInitializer {
         BLOCK_FRAMEWORK.work();
 
         ServerLifecycleEvents.SERVER_STARTING.register(GetAllTrtrBlockCommand :: register);
-
-        // Test ore feature.
-        RegistryKey<PlacedFeature> marbleKey = RegistryKey.of(RegistryKeys.PLACED_FEATURE,
-                                                              new Identifier("trtr",
-                                                                             "ore_xxx"
-                                                              )
-        );
-
-        BiomeModifications.addFeature(BiomeSelectors.foundInOverworld(),
-                                      GenerationStep.Feature.UNDERGROUND_ORES,
-                                      marbleKey
-        );
     }
 
     public static void initializeConfig() {

--- a/src/main/java/com/github/cao/awa/trtr/TrtrMod.java
+++ b/src/main/java/com/github/cao/awa/trtr/TrtrMod.java
@@ -19,7 +19,7 @@ public class TrtrMod implements ModInitializer {
         initializeConfig();
 
         // Register mineable annotations for data generator.
-        MineableAnnotations.putDefaults();
+        MineableAnnotations.register();
 
         // Startup block framework.
         BLOCK_FRAMEWORK.work();

--- a/src/main/java/com/github/cao/awa/trtr/annotation/BlockBelong.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/BlockBelong.java
@@ -2,6 +2,10 @@ package com.github.cao.awa.trtr.annotation;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.apricot.anntation.Stable;
+import com.github.cao.awa.trtr.framework.block.BlockFramework;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +13,28 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Add this annotation in item class for skip item framework load.
+ * <p>
+ * An annotation mark a item type is belong to a block.
+ * </p>
+ * <p>
+ * Mainly used in minecraft item that belong to minecraft block.
+ * </p>
+ * <br>
+ * <p>
+ * This annotation is skip mark, so can also use in other cases, the framework will not process that.
+ * </p>
+ * <br>
+ * <p>
+ * Can only annotate at type location.
+ * </p>
+ *
+ * @author cao_awa
+ * @author 草二号机
+ * @see Item The item
+ * @see Block The block
+ * @see BlockItem BlockItem (Most used in)
+ * @see BlockFramework The block framework
+ * @since 1.0.0
  */
 @Auto
 @Stable

--- a/src/main/java/com/github/cao/awa/trtr/annotation/data/gen/DataGen.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/data/gen/DataGen.java
@@ -2,12 +2,38 @@ package com.github.cao.awa.trtr.annotation.data.gen;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.apricot.anntation.Stable;
+import com.github.cao.awa.trtr.block.example.full.ExampleBlock;
+import com.github.cao.awa.trtr.block.example.simple.SimpleExampleBlock;
+import com.github.cao.awa.trtr.framework.block.data.gen.BlockDataGenFramework;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * An annotation mark a type or field should auto process by datagen framework.
+ * </p>
+ * <p>
+ * Mainly used in minecraft blocks, items, entities and other need process by data generator framework types.
+ * </p>
+ * <br>
+ * <p>
+ * This annotation can also use in other data generator processor marks in other framework.
+ * </p>
+ * <br>
+ * <p>
+ * Can only annotate at field, type, method location.
+ * </p>
+ *
+ * @author cao_awa
+ * @see NoModel
+ * @see BlockDataGenFramework The datagen framework
+ * @see SimpleExampleBlock Simple uses example
+ * @see ExampleBlock Uses example
+ * @since 1.0.0
+ */
 @Auto
 @Stable
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/github/cao/awa/trtr/annotation/mine/repo/MineableAnnotations.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/mine/repo/MineableAnnotations.java
@@ -85,7 +85,7 @@ public class MineableAnnotations {
         return - 1;
     }
 
-    public static void putDefaults() {
+    public static void register() {
         register(AxeMining.class,
                  Identifier.tryParse("minecraft:mineable/axe")
         );

--- a/src/main/java/com/github/cao/awa/trtr/annotation/property/AutoProperty.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/property/AutoProperty.java
@@ -2,12 +2,39 @@ package com.github.cao.awa.trtr.annotation.property;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.apricot.anntation.Stable;
+import com.github.cao.awa.trtr.framework.block.BlockFramework;
+import net.minecraft.state.property.Property;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * An annotation mark a field should auto process by framework.
+ * </p>
+ * <p>
+ * Mainly used in minecraft block state property  {@link  Property net.minecraft.state.property.Property} and impls.
+ * </p>
+ * <br>
+ * <p>
+ * This annotation can also use in other property auto processor marks in other framework.
+ * </p>
+ * <p>
+ * The minecraft block state property framework will ignored not {@link  Property net.minecraft.state.property.Property} field.
+ * </p>
+ * <br>
+ * <p>
+ * Can only annotate at field location.
+ * </p>
+ *
+ * @author 草二号机
+ * @author cao_awa
+ * @see Property Block state property
+ * @see BlockFramework The block framework
+ * @since 1.0.0
+ */
 @Auto
 @Stable
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/github/cao/awa/trtr/annotation/serializer/AutoNbt.java
+++ b/src/main/java/com/github/cao/awa/trtr/annotation/serializer/AutoNbt.java
@@ -2,12 +2,46 @@ package com.github.cao.awa.trtr.annotation.serializer;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.apricot.anntation.Stable;
+import com.github.cao.awa.trtr.block.example.full.entity.ExampleBlockEntity;
+import com.github.cao.awa.trtr.block.example.simple.entity.SimpleExampleBlockEntity;
+import com.github.cao.awa.trtr.framework.nbt.NbtSerializeFramework;
+import com.github.cao.awa.trtr.framework.nbt.serializer.NbtSerializable;
+import com.github.cao.awa.trtr.framework.nbt.serializer.NbtSerializer;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * <p>
+ * An annotation mark a field should auto process serialize and deserialize to the nbt by framework.
+ * </p>
+ * <p>
+ * Mainly used in block entity data and other need nbt serialize types.
+ * </p>
+ * <br>
+ * <p>
+ * This annotation can also use in other nbt auto processor marks in other framework.
+ * </p>
+ * <br>
+ * <p>
+ * Can only annotate at field location.
+ * </p>
+ *
+ * @author cao_awa
+ * @author 草二号机
+ * @see NbtCompound The nbt
+ * @see NbtElement The nbt base
+ * @see NbtSerializeFramework The nbt framework
+ * @see NbtSerializer The nbt serializer
+ * @see NbtSerializable The nbt serializable (Direct serialilzer)
+ * @see SimpleExampleBlockEntity Simple uses example
+ * @see ExampleBlockEntity Uses example
+ * @since 1.0.0
+ */
 @Auto
 @Stable
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/github/cao/awa/trtr/block/TrtrBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/TrtrBlock.java
@@ -1,12 +1,22 @@
 package com.github.cao.awa.trtr.block;
 
 import com.github.cao.awa.apricot.anntation.Auto;
+import com.github.cao.awa.trtr.TrtrMod;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.StateManager;
 
 @Auto
 public abstract class TrtrBlock extends Block {
     @Auto
     public TrtrBlock(Settings settings) {
         super(settings);
+    }
+
+    // Append properties to state builder.
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        TrtrMod.BLOCK_FRAMEWORK.properties(this,
+                                           builder
+        );
     }
 }

--- a/src/main/java/com/github/cao/awa/trtr/block/TrtrBlockWithEntity.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/TrtrBlockWithEntity.java
@@ -46,6 +46,7 @@ public abstract class TrtrBlockWithEntity extends BlockWithEntity {
         );
     }
 
+    // Append properties to state builder.
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
         TrtrMod.BLOCK_FRAMEWORK.properties(this,
                                            builder

--- a/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
@@ -5,6 +5,7 @@ import com.github.cao.awa.trtr.annotation.data.gen.DataGen;
 import com.github.cao.awa.trtr.annotation.dev.DevOnly;
 import com.github.cao.awa.trtr.annotation.mine.AxeMining;
 import com.github.cao.awa.trtr.annotation.mine.PickaxeMining;
+import com.github.cao.awa.trtr.annotation.property.AutoProperty;
 import com.github.cao.awa.trtr.block.TrtrBlock;
 import com.github.cao.awa.trtr.block.example.full.item.ExampleBlockItem;
 import com.github.cao.awa.trtr.block.example.full.loot.ExampleLoot;
@@ -15,6 +16,8 @@ import com.github.cao.awa.trtr.framework.accessor.data.gen.loot.LootFactory;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.yarn.constants.MiningLevels;
 import net.minecraft.block.Material;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.Properties;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 
@@ -81,6 +84,14 @@ public class ExampleBlock extends TrtrBlock {
     // Here one block entity provider is invalid, the name must be "ENTITY" or "BLOCK_ENTITY", framework will ignore it automatically.
     // Direct block tag with class.
     public static final Class<ExampleBlockTag> TYPE_ENTITY = ExampleBlockTag.class;
+
+    // Auto properties to state builder
+    @AutoProperty
+    public static final DirectionProperty DIRECTION = Properties.FACING;
+
+    // This property will not append to state builder, will auto ignored because field type is not 'net.minecraft.state.property.Property'.
+    @AutoProperty
+    public static final String WRONG_PROPERTY = "Test wrong property";
 
     // Constructor...
     @Auto

--- a/src/main/java/com/github/cao/awa/trtr/block/example/full/entity/ExampleBlockEntity.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/full/entity/ExampleBlockEntity.java
@@ -2,15 +2,15 @@ package com.github.cao.awa.trtr.block.example.full.entity;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.trtr.annotation.serializer.AutoNbt;
+import com.github.cao.awa.trtr.block.entity.TrtrBlockEntity;
 import com.github.cao.awa.trtr.block.stove.mud.MudStoveBlockEntity;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 @Auto
-public class ExampleBlockEntity extends BlockEntity {
+public class ExampleBlockEntity extends TrtrBlockEntity {
     // Write to nbt with 'specify_key' like:
     // {
     //     x: 0,

--- a/src/main/java/com/github/cao/awa/trtr/block/example/simple/SimpleExampleBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/simple/SimpleExampleBlock.java
@@ -5,6 +5,7 @@ import com.github.cao.awa.trtr.annotation.data.gen.DataGen;
 import com.github.cao.awa.trtr.annotation.dev.DevOnly;
 import com.github.cao.awa.trtr.annotation.mine.AxeMining;
 import com.github.cao.awa.trtr.annotation.mine.PickaxeMining;
+import com.github.cao.awa.trtr.annotation.property.AutoProperty;
 import com.github.cao.awa.trtr.block.TrtrBlockWithEntity;
 import com.github.cao.awa.trtr.block.example.simple.entity.SimpleExampleBlockEntity;
 import com.github.cao.awa.trtr.block.example.simple.item.SimpleExampleBlockItem;
@@ -14,6 +15,8 @@ import com.github.cao.awa.trtr.block.example.simple.tag.SimpleExampleBlockTag;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.yarn.constants.MiningLevels;
 import net.minecraft.block.Material;
+import net.minecraft.state.property.DirectionProperty;
+import net.minecraft.state.property.Properties;
 import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 
@@ -54,6 +57,14 @@ public class SimpleExampleBlock extends TrtrBlockWithEntity {
     // Block entity.
     @Auto
     public static SimpleExampleBlockEntity ENTITY;
+
+    // Auto properties to state builder
+    @AutoProperty
+    public static final DirectionProperty DIRECTION = Properties.FACING;
+
+    // This property will not append to state builder, will auto ignored because field type is not 'net.minecraft.state.property.Property'.
+    @AutoProperty
+    public static final String WRONG_PROPERTY = "Test wrong property";
 
     // Constructor...
     @Auto

--- a/src/main/java/com/github/cao/awa/trtr/block/example/simple/entity/SimpleExampleBlockEntity.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/simple/entity/SimpleExampleBlockEntity.java
@@ -2,15 +2,15 @@ package com.github.cao.awa.trtr.block.example.simple.entity;
 
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.trtr.annotation.serializer.AutoNbt;
+import com.github.cao.awa.trtr.block.entity.TrtrBlockEntity;
 import com.github.cao.awa.trtr.block.stove.mud.MudStoveBlockEntity;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 @Auto
-public class SimpleExampleBlockEntity extends BlockEntity {
+public class SimpleExampleBlockEntity extends TrtrBlockEntity {
     // Write to nbt with 'specify_key' like:
     // {
     //     x: 0,

--- a/src/main/java/com/github/cao/awa/trtr/framework/block/BlockFramework.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/block/BlockFramework.java
@@ -241,7 +241,19 @@ public class BlockFramework extends ReflectionFramework {
               // Do appends.
               .forEach(field -> EntrustEnvironment.trys(() -> {
                   // Get and ensure it is a property.
-                  Property<?> properties = EntrustEnvironment.cast(field.get(block));
+                  Object fieldResult = field.get(block);
+
+                  if (! (fieldResult instanceof Property<?>)) {
+                      LOGGER.debug("Property in '{}' is not block state property, got type '{}', ignored in block framework",
+                                   block.getClass()
+                                        .getName(),
+                                   fieldResult.getClass()
+                                              .getName()
+                      );
+                      return;
+                  }
+                  Property<?> properties = EntrustEnvironment.cast(fieldResult);
+
                   LOGGER.info("Building property '{}' as '{}' for block '{}' ",
                               field.getName(),
                               field.getType()
@@ -302,7 +314,10 @@ public class BlockFramework extends ReflectionFramework {
                                     // Do not build null identifier block.
                                     // Null identifier means something was wrong.
                                     if (identifier == null) {
-                                        LOGGER.error("Got null identifier, cancel building block '{}'", block.getClass().getName());
+                                        LOGGER.error("Got null identifier, cancel building block '{}'",
+                                                     block.getClass()
+                                                          .getName()
+                                        );
                                         return;
                                     }
 


### PR DESCRIPTION
Add 'appendProperties' method to 'TrtrBlock', used to auto append properties.
Renamed 'putDefaults' to 'register' in 'MineableAnnotations'.
Properties framework will auto ignored wrong type field now, will not notice 'building property' if field wrong.
Example block add property sample and wrongly sample.
Changed example block entities extends 'BlockEntity' to 'TrtrBlockEntity'.
Javadoc in annotations.