### PR TITLE
Readme and some things wrong fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ But there can you to prepare for:
 
 ```
 Java 19
-Fabric Loader 0.14.17
-Fabric API 0.75.3+1.19.4
+Fabric Loader 0.14.21
+Fabric API 0.83.0+1.19.4
 Minecraft 1.19.4
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ The road to reality current planning to a lot of stages.
 |:------------------:|:---------:|:--------------------------:|:----------:|
 |   Stone Overture   | Preparing |         In 3 Years         |    N/A     |
 |     Mine Craft     |   Doing   |         In 5 Years         | 2023.3.12  |
+|   Ceramic Years    |  Waiting  |         In 5 Years         |    N/A     |
 |    Dietary Art     |   Doing   |         Long Term          |  2023.6.1  |
 | Farming Technology | Preparing |         Long Term          |    N/A     |
 | Husbandry Industry | Preparing |         Long Term          |    N/A     |
 |   Water Ecology    |  Waiting  |         In 5 Years         |    N/A     |
 |  Smelting Process  |  Waiting  |         In 5 Years         |    N/A     |
 |  Forging Process   |  Waiting  |         In 5 Years         |    N/A     |
+|     Those Days     |  Waiting  |         In 5 Years         |    N/A     |
+|  System Mysteries  | Preparing |         Long Term          |    N/A     |
 | Actuality Physics  |  Waiting  |         Long Term          |    N/A     |
 |  Fluid Mechanics   |  Waiting  |         Long Term          |    N/A     |
 |     Steam Age      |  Waiting  |         In 3 Years         |    N/A     |
@@ -50,4 +53,3 @@ The road to reality current planning to a lot of stages.
 |  Information Age   |  Waiting  |         In 6 Years         |    N/A     |
 |  Infinite Energy   |  Waiting  |         In 5 Years         |    N/A     |
 |      To Stars      |  Waiting  |         Long Term          |    N/A     |
-| Physical Mysteries | Preparing |         Long Term          |    N/A     |

--- a/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/full/ExampleBlock.java
@@ -6,12 +6,12 @@ import com.github.cao.awa.trtr.annotation.dev.DevOnly;
 import com.github.cao.awa.trtr.annotation.mine.AxeMining;
 import com.github.cao.awa.trtr.annotation.mine.PickaxeMining;
 import com.github.cao.awa.trtr.annotation.property.AutoProperty;
-import com.github.cao.awa.trtr.block.TrtrBlock;
+import com.github.cao.awa.trtr.block.TrtrBlockWithEntity;
+import com.github.cao.awa.trtr.block.example.full.entity.ExampleBlockEntity;
 import com.github.cao.awa.trtr.block.example.full.item.ExampleBlockItem;
 import com.github.cao.awa.trtr.block.example.full.loot.ExampleLoot;
 import com.github.cao.awa.trtr.block.example.full.model.ExampleModel;
 import com.github.cao.awa.trtr.block.example.full.tag.ExampleBlockTag;
-import com.github.cao.awa.trtr.block.example.simple.entity.SimpleExampleBlockEntity;
 import com.github.cao.awa.trtr.framework.accessor.data.gen.loot.LootFactory;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.yarn.constants.MiningLevels;
@@ -25,7 +25,7 @@ import net.minecraft.util.Identifier;
 @DevOnly
 @PickaxeMining(MiningLevels.DIAMOND)
 @AxeMining(MiningLevels.IRON)
-public class ExampleBlock extends TrtrBlock {
+public class ExampleBlock extends TrtrBlockWithEntity {
     // Identifier.
     @Auto
     public static final Identifier IDENTIFIER = Identifier.tryParse("trtr:example");
@@ -79,7 +79,7 @@ public class ExampleBlock extends TrtrBlock {
 
     // Block entity.
     @Auto
-    public static SimpleExampleBlockEntity ENTITY;
+    public static ExampleBlockEntity ENTITY;
 
     // Here one block entity provider is invalid, the name must be "ENTITY" or "BLOCK_ENTITY", framework will ignore it automatically.
     // Direct block tag with class.

--- a/src/main/java/com/github/cao/awa/trtr/block/example/full/entity/ExampleBlockEntity.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/full/entity/ExampleBlockEntity.java
@@ -3,7 +3,6 @@ package com.github.cao.awa.trtr.block.example.full.entity;
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.trtr.annotation.serializer.AutoNbt;
 import com.github.cao.awa.trtr.block.entity.TrtrBlockEntity;
-import com.github.cao.awa.trtr.block.stove.mud.MudStoveBlockEntity;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
@@ -40,9 +39,16 @@ public class ExampleBlockEntity extends TrtrBlockEntity {
     }
 
     @Auto
-    public static void tick(World world, BlockPos pos, BlockState state, MudStoveBlockEntity blockEntity) {
+    public void tick(World world, BlockPos pos, BlockState state) {
         // Tick details...
+        System.out.println(pos);
     }
+
+//    //Or this ways
+//    @Auto
+//    public static void tick(World world, BlockPos pos, BlockState state, MudStoveBlockEntity blockEntity) {
+//         //Tick details...
+//    }
 
     public void somethingTest() {
         this.testInteger = 500;

--- a/src/main/java/com/github/cao/awa/trtr/block/example/simple/entity/SimpleExampleBlockEntity.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/example/simple/entity/SimpleExampleBlockEntity.java
@@ -3,7 +3,6 @@ package com.github.cao.awa.trtr.block.example.simple.entity;
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.trtr.annotation.serializer.AutoNbt;
 import com.github.cao.awa.trtr.block.entity.TrtrBlockEntity;
-import com.github.cao.awa.trtr.block.stove.mud.MudStoveBlockEntity;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.math.BlockPos;
@@ -40,9 +39,16 @@ public class SimpleExampleBlockEntity extends TrtrBlockEntity {
     }
 
     @Auto
-    public static void tick(World world, BlockPos pos, BlockState state, MudStoveBlockEntity blockEntity) {
+    public void tick(World world, BlockPos pos, BlockState state) {
         // Tick details...
+        System.out.println(pos);
     }
+
+//    //Or this ways
+//    @Auto
+//    public static void tick(World world, BlockPos pos, BlockState state, MudStoveBlockEntity blockEntity) {
+//         //Tick details...
+//    }
 
     public void somethingTest() {
         this.testInteger = 500;

--- a/src/main/java/com/github/cao/awa/trtr/block/stove/mud/MudStove.java
+++ b/src/main/java/com/github/cao/awa/trtr/block/stove/mud/MudStove.java
@@ -3,6 +3,7 @@ package com.github.cao.awa.trtr.block.stove.mud;
 import com.github.cao.awa.apricot.anntation.Auto;
 import com.github.cao.awa.apricot.anntation.Unsupported;
 import com.github.cao.awa.trtr.annotation.data.gen.DataGen;
+import com.github.cao.awa.trtr.annotation.dev.DevOnly;
 import com.github.cao.awa.trtr.annotation.property.AutoProperty;
 import com.github.cao.awa.trtr.block.TrtrBlockWithEntity;
 import com.github.cao.awa.trtr.block.stove.mud.model.MudStoveModelProvider;
@@ -32,6 +33,7 @@ import net.minecraft.world.World;
 
 // TODO Waiting for plan 'Smelting Process'
 @Auto
+@DevOnly
 @Unsupported
 public class MudStove extends TrtrBlockWithEntity {
     @Auto
@@ -50,7 +52,6 @@ public class MudStove extends TrtrBlockWithEntity {
 
     @Auto
     public static MudStoveBlockEntity ENTITY;
-
 
     @Auto
     @DataGen

--- a/src/main/java/com/github/cao/awa/trtr/framework/accessor/method/MethodAccess.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/accessor/method/MethodAccess.java
@@ -31,4 +31,20 @@ public class MethodAccess {
         }
         return method;
     }
+
+    public static Method ensureAccessible(Method method, Object object) throws NotStaticFieldException {
+        // Modifier maybe private or without declarations.
+        // Need to make it be accessible.
+        // If unable to access, then throw an exception for notice this error.
+        if (! method.canAccess(object)) {
+            if (method.trySetAccessible()) {
+                return method;
+            }
+            throw new IllegalStateException(StringConcat.concat("The method '",
+                                                                method.getName(),
+                                                                "' with @Auto automatic IoC is not accessible"
+            ));
+        }
+        return method;
+    }
 }

--- a/src/main/java/com/github/cao/awa/trtr/framework/reflection/ReflectionFramework.java
+++ b/src/main/java/com/github/cao/awa/trtr/framework/reflection/ReflectionFramework.java
@@ -73,8 +73,18 @@ public abstract class ReflectionFramework {
 
     @NotNull
     public static Method accessible(Method clazz) {
-        if (clazz.getAnnotation(Auto.class) != null) {
+        if (clazz.isAnnotationPresent(Auto.class)) {
             return MethodAccess.ensureAccessible(clazz);
+        }
+        throw new NoAutoAnnotationException();
+    }
+
+    @NotNull
+    public static Method accessible(Method clazz, Object object) {
+        if (clazz.isAnnotationPresent(Auto.class)) {
+            return MethodAccess.ensureAccessible(clazz,
+                                                 object
+            );
         }
         throw new NoAutoAnnotationException();
     }


### PR DESCRIPTION
Add new planning stages: 'Ceramic Years', 'Those Days'.
Renamed 'Physical Mysteries' to 'System Mysteries'.
Block entity type of block render in block framework from BlockEntityType<MudStoveBlockEntity> to BlockEntityType<BlockEntity>.
Add no static tick method invoke supports.
Ensure accessible use 'isAnnotationPresent' to check auto annotation.
Example block should extend TrtrBlockWithEntity.
The 'ENTITY' field in Example block should be 'ExampleBlockEntity' but got 'SimpleExampleBlockEntity', has changed.
Update version requirement.